### PR TITLE
Fix typo inside the StepManeuver struct

### DIFF
--- a/lib/directions/types.go
+++ b/lib/directions/types.go
@@ -98,7 +98,7 @@ type Lane struct {
 // StepManeuver
 // https://www.mapbox.com/api-documentation/#stepmaneuver-object
 type StepManeuver struct {
-	Locaton       []float64
+	Location       []float64
 	BearingBefore float64
 	BearingAfter  float64
 	Instruction   string


### PR DESCRIPTION
Simply replace `Locaton` with `Location` inside the `StepManeuver` struct from `lib/directions/types.go`