### PR TITLE
Fix segmentation fault on base.QueryRequest request error

### DIFF
--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -98,7 +98,7 @@ func (b *Base) QueryRequest(query string, v *url.Values) (*http.Response, error)
 func (b *Base) QueryBase(query string, v *url.Values, inst interface{}) error {
 	// Make request
 	resp, err := b.QueryRequest(query, v)
-	if err != nil && resp.StatusCode != http.StatusBadRequest {
+	if err != nil && (resp != nil && resp.StatusCode != http.StatusBadRequest) {
 		return err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This is a quick fix on the `base.QueryBase` function to avoid segmentation fault by checking if the `resp` is not nil before to check its status.