### PR TITLE
update constructor to return an error if the token is missing

### DIFF
--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -11,6 +11,7 @@ package base
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -32,12 +33,16 @@ type Base struct {
 }
 
 // NewBase Create a new API base instance
-func NewBase(token string) *Base {
+func NewBase(token string) (*Base, error) {
+	if token == "" {
+		return nil, errors.New("Mapbox API token not found")
+	}
+
 	b := &Base{}
 
 	b.token = token
 
-	return b
+	return b, nil
 }
 
 // SetDebug enables debug output for API calls

--- a/lib/directions/directions.go
+++ b/lib/directions/directions.go
@@ -11,9 +11,10 @@ package directions
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/google/go-querystring/query"
 	"github.com/ryankurte/go-mapbox/lib/base"
-	"strings"
 )
 
 const (

--- a/lib/directions/directions_test.go
+++ b/lib/directions/directions_test.go
@@ -20,13 +20,11 @@ import (
 
 func TestDirections(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 
 	Directions := NewDirections(b)
 

--- a/lib/directions_matrix/directions_matrix_test.go
+++ b/lib/directions_matrix/directions_matrix_test.go
@@ -20,13 +20,11 @@ import (
 
 func TestDirectionsMatrix(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 
 	Directionsmatrix := NewDirectionsMatrix(b)
 

--- a/lib/geocode/geocode_test.go
+++ b/lib/geocode/geocode_test.go
@@ -22,13 +22,11 @@ import (
 
 func TestGeocoder(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 
 	geocode := NewGeocode(b)
 

--- a/lib/map_matching/map_matching_test.go
+++ b/lib/map_matching/map_matching_test.go
@@ -20,13 +20,11 @@ import (
 
 func TestMapMatching(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 
 	MapMatching := NewMapMaptching(b)
 

--- a/lib/mapbox.go
+++ b/lib/mapbox.go
@@ -34,11 +34,15 @@ type Mapbox struct {
 }
 
 // NewMapbox Create a new mapbox API instance
-func NewMapbox(token string) *Mapbox {
+func NewMapbox(token string) (*Mapbox, error) {
 	m := &Mapbox{}
 
 	// Create base instance
-	m.base = base.NewBase(token)
+	base, err := base.NewBase(token)
+	if err != nil {
+		return nil, err
+	}
+	m.base = base
 
 	// Bind modules
 	m.Maps = maps.NewMaps(m.base)
@@ -47,5 +51,5 @@ func NewMapbox(token string) *Mapbox {
 	m.DirectionsMatrix = directionsmatrix.NewDirectionsMatrix(m.base)
 	m.MapMatching = mapmatching.NewMapMaptching(m.base)
 
-	return m
+	return m, nil
 }

--- a/lib/mapbox_test.go
+++ b/lib/mapbox_test.go
@@ -16,18 +16,15 @@ import (
 )
 
 func TestMaps(t *testing.T) {
-	// Fetch token from somewhere
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Errorf("No token found")
+	// Create new mapbox instance
+	mapBox, err := NewMapbox(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
 
-	// Create new mapbox instance
-	mapBox := NewMapbox(token)
-
 	// Map API
-	_, err := mapBox.Maps.GetTile(maps.MapIDSatellite, 1, 0, 1, maps.MapFormatJpg90, true)
+	_, err = mapBox.Maps.GetTile(maps.MapIDSatellite, 1, 0, 1, maps.MapFormatJpg90, true)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/lib/maps/maps_test.go
+++ b/lib/maps/maps_test.go
@@ -21,13 +21,11 @@ import (
 
 func TestMaps(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 	//b.SetDebug(true)
 
 	maps := NewMaps(b)

--- a/lib/maps/tile_test.go
+++ b/lib/maps/tile_test.go
@@ -21,13 +21,11 @@ import (
 
 func TestTiles(t *testing.T) {
 
-	token := os.Getenv("MAPBOX_TOKEN")
-	if token == "" {
-		t.Error("Mapbox API token not found")
+	b, err := base.NewBase(os.Getenv("MAPBOX_TOKEN"))
+	if err != nil {
+		t.Error(err)
 		t.FailNow()
 	}
-
-	b := base.NewBase(token)
 
 	maps := NewMaps(b)
 


### PR DESCRIPTION
Hey @ryankurte,

I have implemented a way to check in the base constructor whether the token provided is empty (invalid) or not, what do you think?

Also, running tests I notices two errors with `Errorf` but I don't think this is related to this PR code, is it?

```
ok  	github.com/ryankurte/go-mapbox/lib	(cached)
?   	github.com/ryankurte/go-mapbox/lib/base	[no test files]
ok  	github.com/ryankurte/go-mapbox/lib/directions	(cached)
ok  	github.com/ryankurte/go-mapbox/lib/directions_matrix	(cached)
ok  	github.com/ryankurte/go-mapbox/lib/geocode	(cached)
ok  	github.com/ryankurte/go-mapbox/lib/map_matching	(cached)
# github.com/ryankurte/go-mapbox/lib/maps
lib/maps/tile.go:48: Errorf format %d has arg offsetX of wrong type float64
lib/maps/tile.go:51: Errorf format %d has arg offsetY of wrong type float64
FAIL	github.com/ryankurte/go-mapbox/lib/maps [build failed]
```

Cheers,

Cédric