### PR TITLE
fix the type of Intersection.Entry

### DIFF
--- a/lib/directions/types.go
+++ b/lib/directions/types.go
@@ -82,7 +82,7 @@ const (
 type Intersection struct {
 	Location []float64
 	Bearings []float64
-	Entry    []string
+	Entry    []bool
 	In       uint
 	Out      uint
 	Lanes    []Lane
@@ -98,7 +98,7 @@ type Lane struct {
 // StepManeuver
 // https://www.mapbox.com/api-documentation/#stepmaneuver-object
 type StepManeuver struct {
-	Location       []float64
+	Location      []float64
 	BearingBefore float64
 	BearingAfter  float64
 	Instruction   string


### PR DESCRIPTION
Hey @ryankurte 

I had errors like this one `json: cannot unmarshal bool into Go struct field Intersection.Entry of type string` while trying to set the `steps=true` flag from the `directions.RequestOpts` before to query the directions API. I fixed it by changing the type of the `directions.Intersection.Entry` field.

is it ok for you?

Cheers,

Cédric