### PR TITLE
Permanent Geocoding Endpoint & Additional Options in Request

### DIFF
--- a/lib/geocode/geocode.go
+++ b/lib/geocode/geocode.go
@@ -12,7 +12,7 @@ package geocode
 import (
 	"fmt"
 	"strings"
-	
+
 	"github.com/google/go-querystring/query"
 	"github.com/ryankurte/go-mapbox/lib/base"
 )
@@ -79,21 +79,21 @@ type ForwardResponse struct {
 // Forward geocode lookup
 // Finds locations from a place name
 func (g *Geocode) Forward(place string, req *ForwardRequestOpts, permanent ...bool) (*ForwardResponse, error) {
-	
+
 	v, err := query.Values(req)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	resp := ForwardResponse{}
-	
+
 	queryString := strings.Replace(place, " ", "+", -1)
 	if len(permanent) > 0 && permanent[0] {
 		err = g.base.Query(apiName, apiVersion, apiModePermanent, fmt.Sprintf("%s.json", queryString), &v, &resp)
 	} else {
 		err = g.base.Query(apiName, apiVersion, apiMode, fmt.Sprintf("%s.json", queryString), &v, &resp)
 	}
-	
+
 	return &resp, err
 }
 
@@ -112,17 +112,17 @@ type ReverseResponse struct {
 // Reverse geocode lookup
 // Finds place names from a location
 func (g *Geocode) Reverse(loc *base.Location, req *ReverseRequestOpts) (*ReverseResponse, error) {
-	
+
 	v, err := query.Values(req)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	resp := ReverseResponse{}
-	
+
 	queryString := fmt.Sprintf("%f,%f.json", loc.Longitude, loc.Latitude)
-	
+
 	err = g.base.Query(apiName, apiVersion, apiMode, queryString, &v, &resp)
-	
+
 	return &resp, err
 }


### PR DESCRIPTION
Mapbox has a special endpoint for permanent geocoding which must be used for permanent geocoding requirements. This PR enables such endpoint without harming the existing code. 

Also adds the recently added few more features on the Mapbox API. 
- Routing (Alpha) - Produces a routable point to the relevant item if available
- FuzzyMatching

